### PR TITLE
bump version for gem push

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a plugin for [pre-commit](https://pre-commit.com) that will sign your co
 To sign commits as part of your pre-commit flow, just run the sign-commit hook of this repo.
 
     - repo: https://github.com/mattlqx/pre-commit-sign
-      rev: v1.1.0
+      rev: v1.1.1
       hooks:
       - id: sign-commit
 

--- a/pre-commit-sign.gemspec
+++ b/pre-commit-sign.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'pre-commit-sign'
-  s.version     = '1.1.0'
+  s.version     = '1.1.1'
   s.licenses    = ['MIT']
   s.summary     = 'Pre-commit plugin for signing commits'
   s.description = 'This pre-commit plugin will hash certain fields of the commit message and sign it.'


### PR DESCRIPTION
Yanked v1.1.0 because of CircleCI testing, didn't realize you can't repush after that. So bumping to v1.1.1.